### PR TITLE
feat: add pricing grid component

### DIFF
--- a/SolCipher/app/src/components/PricingGrid.tsx
+++ b/SolCipher/app/src/components/PricingGrid.tsx
@@ -1,0 +1,132 @@
+import React from "react";
+
+type Plan = {
+  name: string;
+  priceMonthly: number | "custom";
+  features: string[];
+  cta: { label: string; href: string };
+  highlight?: boolean;
+};
+
+const plans: Plan[] = [
+  {
+    name: "Free",
+    priceMonthly: 0,
+    features: [
+      "1 GB storage",
+      "100 MB per file",
+      "2 links/day",
+      "7-day expiry",
+      "Community support",
+      "E2E encryption"
+    ],
+    cta: { label: "Start free", href: "/signup" }
+  },
+  {
+    name: "Personal",
+    priceMonthly: 6,
+    features: [
+      "50 GB storage",
+      "2 GB per file",
+      "Unlimited links",
+      "30-day expiry",
+      "Email support",
+      "IPFS pinning"
+    ],
+    cta: { label: "Go Personal", href: "/checkout?plan=personal" }
+  },
+  {
+    name: "Pro",
+    priceMonthly: 14,
+    features: [
+      "200 GB storage",
+      "5 GB per file",
+      "Custom expiry",
+      "Versioning",
+      "Priority support",
+      "On-chain receipts"
+    ],
+    cta: { label: "Upgrade to Pro", href: "/checkout?plan=pro" },
+    highlight: true
+  },
+  {
+    name: "Team",
+    priceMonthly: 49,
+    features: [
+      "1 TB pooled",
+      "10 GB per file",
+      "Up to 10 seats",
+      "Roles & audit log",
+      "SSO-lite",
+      "API access"
+    ],
+    cta: { label: "Start Team", href: "/checkout?plan=team" }
+  },
+  {
+    name: "Enterprise",
+    priceMonthly: "custom",
+    features: [
+      "SSO/SAML + SCIM",
+      "BYOK / on-prem KMS",
+      "DPA & audit support",
+      "99.9% uptime SLA",
+      "Named TAM"
+    ],
+    cta: { label: "Request a quote", href: "/contact?topic=enterprise" }
+  }
+];
+
+export default function PricingGrid() {
+  return (
+    <section className="mx-auto max-w-6xl px-4 py-16">
+      <header className="mb-12 text-center">
+        <h1 className="text-3xl font-bold">Choose your plan</h1>
+        <p className="mt-2 text-sm text-gray-600">Cancel anytime. Taxes may apply.</p>
+      </header>
+
+      <div className="grid gap-6 md:grid-cols-2 lg:grid-cols-5">
+        {plans.map((p) => (
+          <article
+            key={p.name}
+            className={`rounded-2xl border p-6 shadow-sm ${
+              p.highlight ? "border-black shadow-lg" : "border-gray-200"
+            }`}
+          >
+            <h2 className="text-lg font-semibold">{p.name}</h2>
+            <div className="mt-3">
+              {p.priceMonthly === "custom" ? (
+                <span className="text-3xl font-bold">Custom</span>
+              ) : (
+                <span className="text-3xl font-bold">${p.priceMonthly}</span>
+              )}
+              {p.priceMonthly !== "custom" && <span className="text-sm text-gray-500">/mo</span>}
+            </div>
+
+            <ul className="mt-4 space-y-2 text-sm">
+              {p.features.map((f) => (
+                <li key={f} className="flex items-start gap-2">
+                  <span aria-hidden>✓</span>
+                  <span>{f}</span>
+                </li>
+              ))}
+            </ul>
+
+            <a
+              href={p.cta.href}
+              className={`mt-6 inline-block w-full rounded-xl px-4 py-2 text-center text-sm font-medium ${
+                p.highlight ? "bg-black text-white" : "bg-gray-100 hover:bg-gray-200"
+              }`}
+            >
+              {p.cta.label}
+            </a>
+          </article>
+        ))}
+      </div>
+
+      <p className="mt-8 text-center text-xs text-gray-500">
+        Need invoices, crypto payments, or yearly billing? <a href="/contact" className="underline">Contact sales</a>.
+      </p>
+    </section>
+  );
+}
+

--- a/SolCipher/pricing.html
+++ b/SolCipher/pricing.html
@@ -1,0 +1,86 @@
+<!DOCTYPE html>
+<html lang="en">
+<head>
+  <meta charset="UTF-8" />
+  <meta name="viewport" content="width=device-width, initial-scale=1.0" />
+  <title>Pricing - SolCipher</title>
+  <link rel="canonical" href="https://solcipher.pro/pricing" />
+  <style>
+    .container{max-width:1120px;margin:0 auto;padding:64px 16px;text-align:center}
+    .sub{color:#6b7280;font-size:14px;margin-top:4px}
+    .grid{display:grid;gap:16px;margin-top:24px}
+    @media (min-width:768px){.grid{grid-template-columns:repeat(3,1fr)}}
+    @media (min-width:1024px){.grid{grid-template-columns:repeat(5,1fr)}}
+    .card{border:1px solid #e5e7eb;border-radius:16px;padding:20px;text-align:left}
+    .highlight{border-color:#111827;box-shadow:0 8px 24px rgba(0,0,0,.08)}
+    .price{font-size:28px;font-weight:700;margin:8px 0}
+    .price span{font-size:12px;color:#6b7280;margin-left:2px}
+    ul{list-style:none;padding:0;margin:12px 0}
+    li{display:flex;gap:8px;margin:6px 0}
+    li::before{content:"\2713"}
+    .btn{display:block;text-align:center;margin-top:12px;padding:10px 14px;border-radius:12px;background:#f3f4f6}
+    .btn:hover{background:#e5e7eb}
+    .primary{background:#111827;color:#fff}
+    .foot{font-size:12px;color:#6b7280;margin-top:16px}
+  </style>
+</head>
+<body>
+<section class="container">
+  <h1>Choose your plan</h1>
+  <p class="sub">Cancel anytime. Taxes may apply.</p>
+  <div class="grid">
+    <!-- Free -->
+    <article class="card">
+      <h2>Free</h2>
+      <div class="price">$0<span>/mo</span></div>
+      <ul>
+        <li>1 GB storage</li><li>100 MB/file</li><li>2 links/day</li>
+        <li>7-day expiry</li><li>E2E encryption</li>
+      </ul>
+      <a class="btn" href="/signup">Start free</a>
+    </article>
+    <!-- Personal -->
+    <article class="card">
+      <h2>Personal</h2>
+      <div class="price">$6<span>/mo</span></div>
+      <ul>
+        <li>50 GB storage</li><li>2 GB/file</li><li>Unlimited links</li>
+        <li>30-day expiry</li><li>Email support</li>
+      </ul>
+      <a class="btn" href="/checkout?plan=personal">Go Personal</a>
+    </article>
+    <!-- Pro (highlight) -->
+    <article class="card highlight">
+      <h2>Pro</h2>
+      <div class="price">$14<span>/mo</span></div>
+      <ul>
+        <li>200 GB storage</li><li>5 GB/file</li><li>Custom expiry</li>
+        <li>Versioning</li><li>Priority support</li>
+      </ul>
+      <a class="btn primary" href="/checkout?plan=pro">Upgrade to Pro</a>
+    </article>
+    <!-- Team -->
+    <article class="card">
+      <h2>Team</h2>
+      <div class="price">$49<span>/mo</span></div>
+      <ul>
+        <li>1 TB pooled</li><li>10 seats</li><li>10 GB/file</li>
+        <li>Roles & audit log</li><li>API access</li>
+      </ul>
+      <a class="btn" href="/checkout?plan=team">Start Team</a>
+    </article>
+    <!-- Enterprise -->
+    <article class="card">
+      <h2>Enterprise</h2>
+      <div class="price">Custom</div>
+      <ul>
+        <li>SSO/SAML + SCIM</li><li>BYOK / on-prem KMS</li>
+        <li>DPA & 99.9% SLA</li><li>Named TAM</li>
+      </ul>
+      <a class="btn" href="/contact?topic=enterprise">Request a quote</a>
+    </article>
+  </div>
+  <p class="foot">Need crypto payments or annual billing? <a href="/contact">Contact sales</a>.</p>
+</section>
+</body>
+</html>

--- a/vercel.json
+++ b/vercel.json
@@ -1,0 +1,9 @@
+{
+  "rewrites": [
+    { "source": "/encrypt/:path*", "destination": "https://solcipher.online/:path*" },
+    { "source": "/share/:path*",   "destination": "https://solcipher.cloud/:path*" }
+  ],
+  "redirects": [
+    { "source": "/services", "destination": "/encrypt", "permanent": true }
+  ]
+}


### PR DESCRIPTION
## Summary
- add static pricing page with plan cards and highlight styling
- configure Vercel rewrites to proxy encrypt and share tools under single domain

## Testing
- `npm install` *(fails: No matching version found for @project-serum/anchor@^0.28.0)*
- `npm test` *(fails: Missing script: "test")*
- `npm run build` *(fails: vite: not found)*
- `curl -I https://solcipher.pro/pricing` *(fails: CONNECT tunnel failed, response 403)*
- `curl -I https://solcipher.pro/encrypt` *(fails: CONNECT tunnel failed, response 403)*
- `curl -I https://solcipher.pro/share` *(fails: CONNECT tunnel failed, response 403)*

------
https://chatgpt.com/codex/tasks/task_e_68ba0f62747083338a08105af074b053